### PR TITLE
Add a new hotkey to close the interface

### DIFF
--- a/RecipeBrowser.cs
+++ b/RecipeBrowser.cs
@@ -37,6 +37,7 @@ namespace RecipeBrowser
 		//internal static Dictionary<string, LocalizedText> translations; // reference to private field.
 		internal static Mod itemChecklistInstance;
 		internal ModKeybind ToggleRecipeBrowserHotKey;
+		internal ModKeybind CloseRecipeBrowserHotKey;
 		internal ModKeybind QueryHoveredItemHotKey;
 		internal ModKeybind ToggleFavoritedPanelHotKey;
 
@@ -80,6 +81,7 @@ namespace RecipeBrowser
 			{
 			*/
 			ToggleRecipeBrowserHotKey = KeybindLoader.RegisterKeybind(this, "ToggleRecipeBrowser", "OemCloseBrackets");
+			CloseRecipeBrowserHotKey = KeybindLoader.RegisterKeybind(this, "CloseRecipeBrowser", "Esc");
 			QueryHoveredItemHotKey = KeybindLoader.RegisterKeybind(this, "QueryHoveredItem", "Mouse3");
 			ToggleFavoritedPanelHotKey = KeybindLoader.RegisterKeybind(this, "ToggleFavoritedRecipesWindow", "F3");
 			/*
@@ -118,6 +120,7 @@ namespace RecipeBrowser
 			itemChecklistInstance = null;
 			LootCache.instance = null;
 			ToggleRecipeBrowserHotKey = null;
+			CloseRecipeBrowserHotKey = null;
 			QueryHoveredItemHotKey = null;
 			RecipeBrowserUI.instance = null;
 			RecipeCatalogueUI.instance = null;

--- a/RecipeBrowserPlayer.cs
+++ b/RecipeBrowserPlayer.cs
@@ -174,6 +174,18 @@ namespace RecipeBrowser
 		{
 			//if (!RecipeBrowser.instance.CheatSheetLoaded)
 			{
+				if (RecipeBrowser.instance.CloseRecipeBrowserHotKey.JustPressed)
+				{
+					RecipeBrowserUI.instance.ShowRecipeBrowser = false;
+					// Debug assistance, allows for reinitializing RecipeBrowserUI
+					//if (!RecipeBrowserUI.instance.ShowRecipeBrowser)
+					//{
+					//	RecipeBrowserUI.instance.RemoveAllChildren();
+					//	var isInitializedFieldInfo = typeof(Terraria.UI.UIElement).GetField("_isInitialized", BindingFlags.Instance | BindingFlags.NonPublic);
+					//	isInitializedFieldInfo.SetValue(RecipeBrowserUI.instance, false);
+					//	RecipeBrowserUI.instance.Activate();
+					//}
+				}
 				if (RecipeBrowser.instance.ToggleRecipeBrowserHotKey.JustPressed)
 				{
 					RecipeBrowserUI.instance.ShowRecipeBrowser = !RecipeBrowserUI.instance.ShowRecipeBrowser;


### PR DESCRIPTION
occasionally, if the UI toggle hotkey is more accessible, it can be accidentally pressed. This adds the option to set a close hotkey for if you happen to open the recipe browser during a boss fight or something