### PR TITLE
Made Armor Set calculations run asynchronously

### DIFF
--- a/ItemCatalogueUI.cs
+++ b/ItemCatalogueUI.cs
@@ -298,7 +298,7 @@ namespace RecipeBrowser
 
 			if (SharedUI.instance.SelectedCategory.name == ArmorSetFeatureHelper.ArmorSetsHoverTest) {
 				if (ArmorSetFeatureHelper.hasCalculated == false && ArmorSetFeatureHelper.hasStarted != true)
-					await Task.Run(() => ArmorSetFeatureHelper.CalculateArmorSets());           //TODO: make this run on a separate thread
+					await Task.Run(() => ArmorSetFeatureHelper.CalculateArmorSets());           
 				if (ArmorSetFeatureHelper.hasCalculated && ArmorSetFeatureHelper.armorSetSlotsMutex.WaitOne(10))
 				{
 					slotsToUse = ArmorSetFeatureHelper.armorSetSlots.Cast<UIItemCatalogueItemSlot>().ToList();

--- a/ItemCatalogueUI.cs
+++ b/ItemCatalogueUI.cs
@@ -297,16 +297,18 @@ namespace RecipeBrowser
 			List<UIItemCatalogueItemSlot> slotsToUse = itemSlots;
 
 			if (SharedUI.instance.SelectedCategory.name == ArmorSetFeatureHelper.ArmorSetsHoverTest) {
-				if (ArmorSetFeatureHelper.hasCalculated == false && ArmorSetFeatureHelper.hasStarted != true)
+				if (!(ArmorSetFeatureHelper.hasCalculated) && !(ArmorSetFeatureHelper.hasStarted))
 					await Task.Run(() => ArmorSetFeatureHelper.CalculateArmorSets());           
 				if (ArmorSetFeatureHelper.hasCalculated && ArmorSetFeatureHelper.armorSetSlotsMutex.WaitOne(10))
 				{
 					slotsToUse = ArmorSetFeatureHelper.armorSetSlots.Cast<UIItemCatalogueItemSlot>().ToList();
 					ArmorSetFeatureHelper.armorSetSlotsMutex.ReleaseMutex();
-				}
+
+                    ArmorSetFeatureHelper.AppendSpecialUI(itemGrid);
+                }
 				else
 					slotsToUse = new List<UIItemCatalogueItemSlot>(); //empty
-				ArmorSetFeatureHelper.AppendSpecialUI(itemGrid);
+				
 			}
 
 			foreach (var slot in slotsToUse)

--- a/UIElements/UIArmorSetCatalogueItemSlot.cs
+++ b/UIElements/UIArmorSetCatalogueItemSlot.cs
@@ -288,22 +288,22 @@ namespace RecipeBrowser.UIElements
 				item.SetDefaults(type, false);
 
 				
-				if (item.type == ItemID.None)       // Case where we get a gap in item id's?
+				if (item.type == ItemID.None)      
                     continue;
 
-				if (item.headSlot != -1)			// if item is a helmet
+				if (item.headSlot != -1)			
 					Heads.Add(item);
-				if (item.bodySlot != -1)			// if item is a chestplate
+				if (item.bodySlot != -1)			
 					Bodys.Add(item);
-				if (item.legSlot != -1)				// if item is leggings
+				if (item.legSlot != -1)				
 					Legs.Add(item);
 			}
 
-			sets = new List<Tuple<Item, Item, Item, string, int>>();	// tuple is (helmet, chestplate, leggings, set Bonus, total defense [incl any from set bonus])
+			sets = new List<Tuple<Item, Item, Item, string, int>>();	
 			foreach (var head in Heads) {
 				foreach (var body in Bodys) {
 					foreach (var leg in Legs) {
-						// TODO: thread this shit to hell and back to speed up efficiency.
+						
 						testPlayer.statDefense = Player.DefenseStat.Default;
 						testPlayer.head = head.headSlot;
 						testPlayer.body = body.bodySlot;
@@ -382,7 +382,7 @@ namespace RecipeBrowser.UIElements
 					armorSetSlots.Add(slot);
 				}
 			}
-			armorSetSlotsMutex.ReleaseMutex();			//release mutex
+			armorSetSlotsMutex.ReleaseMutex();			     //release mutex
 			hasCalculated = true;
 			
 		}


### PR DESCRIPTION
Note: this just made the function that calculates armor sets run on another thread (it otherwise remains mostly unchanged).

I didn't want to restructure the code too much, but ArmorSetFeatureHelper.armorSetSlots should *only* be accessed when the mutex is held. It's a quick and dirty solution, but it seems to work and it's better than having your game freeze for an uncomfortable amount of time after clicking the armor set tab.

I've tested this in both vanilla and calamity and haven't had any crashes or issues with the latest commit. Please tell me if you run into any issues. 