### PR TITLE
feat: button in mod config for direct access to keybindings menu

### DIFF
--- a/Localization/TranslationsNeeded.txt
+++ b/Localization/TranslationsNeeded.txt
@@ -1,4 +1,4 @@
-en-US, 238/240, 99%, missing 2
+en-US, 240/240, 100%, missing 0
 de-DE, 28/240, 12%, missing 212
 it-IT, 28/240, 12%, missing 212
 fr-FR, 95/240, 40%, missing 145
@@ -6,4 +6,4 @@ es-ES, 49/240, 20%, missing 191
 ru-RU, 238/240, 99%, missing 2
 zh-Hans, 240/240, 100%, missing 0
 pt-BR, 95/240, 40%, missing 145
-pl-PL, 85/240, 35%, missing 155
+pl-PL, 87/240, 36%, missing 153

--- a/Localization/de-DE.hjson
+++ b/Localization/de-DE.hjson
@@ -384,6 +384,11 @@ Mods: {
 					// Tooltip: Show which mod adds which NPC in the bestiary. Disable for immersion.
 				}
 
+				OpenKeybindingsMenuButton: {
+					// Label: Open Keybindings Menu
+					// Tooltip: Open the keybindings menu to change the hotkeys for this mod
+				}
+
 				// Headers.AutomaticSettings: Automatic Settings
 
 				RecipeBrowserSize: {

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -388,6 +388,11 @@ Mods: {
 					Tooltip: Show which mod adds which NPC in the bestiary. Disable for immersion.
 				}
 
+				OpenKeybindingsMenuButton: {
+					Label: Open Keybindings Menu
+					Tooltip: Open the keybindings menu to change the hotkeys for this mod
+				}
+
 				Headers.AutomaticSettings: Automatic Settings
 
 				RecipeBrowserSize: {

--- a/Localization/es-ES.hjson
+++ b/Localization/es-ES.hjson
@@ -384,6 +384,11 @@ Mods: {
 					// Tooltip: Show which mod adds which NPC in the bestiary. Disable for immersion.
 				}
 
+				OpenKeybindingsMenuButton: {
+					// Label: Open Keybindings Menu
+					// Tooltip: Open the keybindings menu to change the hotkeys for this mod
+				}
+
 				// Headers.AutomaticSettings: Automatic Settings
 
 				RecipeBrowserSize: {

--- a/Localization/fr-FR.hjson
+++ b/Localization/fr-FR.hjson
@@ -405,6 +405,11 @@ Mods: {
 					Tooltip: Montrer quel mod ajoute quel PNJ dans le bestiaire. Désactiver pour l'immersion.
 				}
 
+				OpenKeybindingsMenuButton: {
+					// Label: Open Keybindings Menu
+					// Tooltip: Open the keybindings menu to change the hotkeys for this mod
+				}
+
 				Headers.AutomaticSettings: Paramètres automatiques
 
 				RecipeBrowserSize: {

--- a/Localization/it-IT.hjson
+++ b/Localization/it-IT.hjson
@@ -384,6 +384,11 @@ Mods: {
 					// Tooltip: Show which mod adds which NPC in the bestiary. Disable for immersion.
 				}
 
+				OpenKeybindingsMenuButton: {
+					// Label: Open Keybindings Menu
+					// Tooltip: Open the keybindings menu to change the hotkeys for this mod
+				}
+
 				// Headers.AutomaticSettings: Automatic Settings
 
 				RecipeBrowserSize: {

--- a/Localization/pl-PL.hjson
+++ b/Localization/pl-PL.hjson
@@ -384,6 +384,11 @@ Mods: {
 					Tooltip: Pokaż, który mod dodaje jakiego NPC w bestiariuszu. Wyłącz, aby pochłonąć się w grze.
 				}
 
+				OpenKeybindingsMenuButton: {
+					Label: Otwórz menu przypisań klawiszy
+					Tooltip: Otwórz menu przypisań klawiszy, aby zmienić skróty klawiszowe dla tego moda
+				}
+
 				Headers.AutomaticSettings: Automatyczne Ustawienia
 
 				RecipeBrowserSize: {

--- a/Localization/pt-BR.hjson
+++ b/Localization/pt-BR.hjson
@@ -384,6 +384,11 @@ Mods: {
 					Tooltip: Mostrar qual mod adiciona qual NPC no bestiário. Desativar para imersão.
 				}
 
+				OpenKeybindingsMenuButton: {
+					// Label: Open Keybindings Menu
+					// Tooltip: Open the keybindings menu to change the hotkeys for this mod
+				}
+
 				Headers.AutomaticSettings: Configurações Automáticas
 
 				RecipeBrowserSize: {

--- a/Localization/ru-RU.hjson
+++ b/Localization/ru-RU.hjson
@@ -405,6 +405,11 @@ Mods: {
 					Tooltip: Рядом с названием существа в меню существ будет написано, какой именно мод добавляет его
 				}
 
+				OpenKeybindingsMenuButton: {
+					// Label: Open Keybindings Menu
+					// Tooltip: Open the keybindings menu to change the hotkeys for this mod
+				}
+
 				Headers.AutomaticSettings: Автоматические настройки
 
 				RecipeBrowserSize: {

--- a/Localization/zh-Hans.hjson
+++ b/Localization/zh-Hans.hjson
@@ -388,6 +388,11 @@ Mods: {
 					Tooltip: 显示图鉴中的NPC由哪个模组添加. 沉浸式体验请禁用.
 				}
 
+				OpenKeybindingsMenuButton: {
+					// Label: Open Keybindings Menu
+					// Tooltip: Open the keybindings menu to change the hotkeys for this mod
+				}
+
 				Headers.AutomaticSettings: 自动设置
 
 				RecipeBrowserSize: {

--- a/RecipeBrowser.cs
+++ b/RecipeBrowser.cs
@@ -65,6 +65,8 @@ namespace RecipeBrowser
 			ChatManager.Register<TagHandlers.ItemHoverFixTagHandler>("itemhover");
 			//ChatManager.Register<TagHandlers.URLTagHandler>("u", "url");
 
+			Main.Assets.Request<Texture2D>("Images/UI/Settings_Inputs"); // Preload texture for OpenKeybindingsMenuButton
+
 			//FieldInfo translationsField = typeof(LocalizationLoader).GetField("translations", BindingFlags.Static | BindingFlags.NonPublic);
 			//translations = (Dictionary<string, LocalizedText>)translationsField.GetValue(this);
 			

--- a/RecipeBrowserClientConfig.cs
+++ b/RecipeBrowserClientConfig.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.Xna.Framework;
 using System.ComponentModel;
 using System.Reflection;
-using System.Text.Json.Serialization;
 using RecipeBrowser.UIElements;
 using Terraria.ModLoader;
 using Terraria.ModLoader.Config;
+using Newtonsoft.Json;
 
 namespace RecipeBrowser
 {
@@ -24,7 +24,7 @@ namespace RecipeBrowser
 		public bool ShowNPCModSource { get; set; }
 
 		[CustomModConfigItem(typeof(OpenKeybindingsMenuButton))]
-		[JsonIgnore]
+		[JsonIgnore, ShowDespiteJsonIgnore]
 		public bool OpenKeybindingsMenuButton { get; set; }
 
 		[Header("AutomaticSettings")]

--- a/RecipeBrowserClientConfig.cs
+++ b/RecipeBrowserClientConfig.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
 using System.ComponentModel;
 using System.Reflection;
+using System.Text.Json.Serialization;
+using RecipeBrowser.UIElements;
 using Terraria.ModLoader;
 using Terraria.ModLoader.Config;
 
@@ -20,6 +22,10 @@ namespace RecipeBrowser
 
 		[DefaultValue(true)]
 		public bool ShowNPCModSource { get; set; }
+
+		[CustomModConfigItem(typeof(OpenKeybindingsMenuButton))]
+		[JsonIgnore]
+		public bool OpenKeybindingsMenuButton { get; set; }
 
 		[Header("AutomaticSettings")]
 		// non-player specific stuff:

--- a/UIElements/OpenKeybindingsMenuButton.cs
+++ b/UIElements/OpenKeybindingsMenuButton.cs
@@ -1,10 +1,13 @@
 #nullable enable
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Terraria;
+using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
 using Terraria.GameContent.UI.States;
+using Terraria.ID;
 using Terraria.ModLoader.Config.UI;
 using Terraria.UI;
 
@@ -17,14 +20,34 @@ namespace RecipeBrowser.UIElements;
 /// </summary>
 public class OpenKeybindingsMenuButton : ConfigElement<bool>
 {
-	private readonly UIElement _buttonElement = new() { Width = { Percent = 1f }, Height = { Percent = 1f } };
-
 	public override void OnBind()
 	{
 		base.OnBind();
 
-		_buttonElement.OnLeftClick += (_, _) => HandleButtonClick();
-		Append(_buttonElement);
+		var keybindTexture = Main.Assets.Request<Texture2D>("Images/UI/Settings_Inputs");
+		var keybindUIImage = new UIImageFramed(keybindTexture, keybindTexture.Frame(1, 2, sizeOffsetY: -2)) {
+			VAlign = 0f,
+			HAlign = 1f,
+			Left =new StyleDimension(-40f, 0f),
+			Top = new StyleDimension(4f, 0f),
+			IgnoresMouseInteraction = true
+		};
+		Append(keybindUIImage);
+
+		var gotoUIImage = new UIImage(Main.Assets.Request<Texture2D>("Images/UI/Bestiary/Button_Forward")) {
+			Left = new StyleDimension(-6, 0f),
+			Top = new StyleDimension(6, 0f),
+			HAlign = 1f,
+			IgnoresMouseInteraction = true
+		};
+		Append(gotoUIImage);
+
+		Height.Set(40f, 0f);
+	}
+
+	public override void LeftClick(UIMouseEvent evt) {
+		base.LeftClick(evt);
+		HandleButtonClick();
 	}
 
 	/// <summary>
@@ -49,6 +72,7 @@ public class OpenKeybindingsMenuButton : ConfigElement<bool>
 		{
 			ScrollToSubcategory(controlsUi, RecipeBrowser.instance.Name);
 		}
+		SoundEngine.PlaySound(SoundID.MenuOpen);
 	}
 
 	/// <summary>

--- a/UIElements/OpenKeybindingsMenuButton.cs
+++ b/UIElements/OpenKeybindingsMenuButton.cs
@@ -1,0 +1,121 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Terraria;
+using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
+using Terraria.ModLoader.Config.UI;
+using Terraria.UI;
+
+namespace RecipeBrowser.UIElements;
+
+/// <summary>
+/// A configuration element that shows a button opening the keybindings UI and scrolls
+/// directly to this mod's controls category within the controls menu.
+/// Calculates and applies the scroll offset cumulatively on each click, based on the current UI state.
+/// </summary>
+public class OpenKeybindingsMenuButton : ConfigElement<bool>
+{
+	private readonly UIElement _buttonElement = new() { Width = { Percent = 1f }, Height = { Percent = 1f } };
+
+	public override void OnBind()
+	{
+		base.OnBind();
+
+		_buttonElement.OnLeftClick += (_, _) => HandleButtonClick();
+		Append(_buttonElement);
+	}
+
+	/// <summary>
+	/// Handles button click: opens the keybinds UI and scrolls to the correct subcategory for this mod.
+	/// </summary>
+	private static void HandleButtonClick()
+	{
+		UIManageControls? controlsUi;
+
+		if (Main.gameMenu)
+		{
+			Main.MenuUI.SetState(Main.ManageControlsMenu);
+			controlsUi = Main.MenuUI.CurrentState as UIManageControls;
+		}
+		else
+		{
+			IngameFancyUI.OpenKeybinds();
+			controlsUi = Main.InGameUI.CurrentState as UIManageControls;
+		}
+
+		if (controlsUi is not null)
+		{
+			ScrollToSubcategory(controlsUi, RecipeBrowser.instance.Name);
+		}
+	}
+
+	/// <summary>
+	/// Scrolls the controls UI to the header that matches <paramref name="modName"/>.
+	/// Calculates offset based on header and view positions each time, without relying on cached values.
+	/// </summary>
+	private static void ScrollToSubcategory(UIManageControls controls, string modName)
+	{
+		controls.Recalculate();
+
+		var scrollbar = UIElementHelpers.FindChildOfType<UIScrollbar>(controls);
+		if (scrollbar == null)
+		{
+			return;
+		}
+
+		scrollbar.Recalculate();
+
+		var uiList = UIElementHelpers.FindChildOfType<UIList>(
+			controls,
+			list =>
+			{
+				var field =
+					typeof(UIList).GetField("_scrollbar", BindingFlags.Instance | BindingFlags.NonPublic)
+					?? typeof(UIList).GetField("_scrollBar", BindingFlags.Instance | BindingFlags.NonPublic);
+				return field?.GetValue(list) == scrollbar;
+			}
+		);
+
+		if (uiList == null)
+		{
+			return;
+		}
+
+		uiList.Recalculate();
+
+		var headerType = typeof(UIManageControls).Assembly.GetType("Terraria.ModLoader.Config.UI.HeaderElement");
+		var headerField = headerType?.GetField("header", BindingFlags.Instance | BindingFlags.NonPublic);
+		if (headerType == null || headerField == null)
+		{
+			return;
+		}
+
+		var headers = new List<UIElement>();
+		UIElementHelpers.GatherElementsByType(uiList, headerType, headers);
+
+		var target = headers.Find(h =>
+		{
+			var text = headerField.GetValue(h) as string ?? "";
+			return string.Equals(text.Replace(" ", ""), modName, StringComparison.InvariantCultureIgnoreCase);
+		});
+		if (target == null)
+		{
+			return;
+		}
+
+		target.Recalculate();
+
+		float headerY = target.GetDimensions().Y;
+		float viewY = uiList.GetInnerDimensions().Y;
+		float previousOffset = scrollbar.ViewPosition;
+		float rawOffset = Math.Max(0f, headerY - viewY);
+
+		var maxSizeProp = typeof(UIScrollbar).GetProperty("MaxViewSize", BindingFlags.Instance | BindingFlags.Public);
+		float maxView = (float?)(maxSizeProp?.GetValue(scrollbar)) ?? rawOffset;
+		float offset = Math.Clamp(previousOffset + rawOffset, 0f, maxView);
+
+		scrollbar.ViewPosition = offset;
+	}
+}

--- a/UIElements/UIElementHelpers.cs
+++ b/UIElements/UIElementHelpers.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Terraria.UI;
+
+namespace RecipeBrowser.UIElements;
+
+/// <summary>
+/// Provides utility methods for recursively traversing, searching, and extracting elements from UIElement hierarchies.
+/// Useful for locating and collecting specific UI controls in complex Terraria UI trees.
+/// </summary>
+internal static class UIElementHelpers
+{
+	/// <summary>
+	/// Recursively searches all children of the given UIElement and collects every element whose runtime type matches the specified <paramref name="type"/>.
+	/// This is useful for gathering all elements of a particular kind (such as headers or buttons) in complex, nested UI layouts.
+	/// </summary>
+	/// <param name="parent">The root UIElement from which to start searching.</param>
+	/// <param name="type">The exact runtime type to match against child elements.</param>
+	/// <param name="outList">The list where all matching elements will be added.</param>
+	internal static void GatherElementsByType(UIElement parent, Type type, List<UIElement> outList)
+	{
+		foreach (var child in parent.Children)
+		{
+			if (child.GetType() == type)
+			{
+				outList.Add(child);
+			}
+			GatherElementsByType(child, type, outList);
+		}
+	}
+
+	/// <summary>
+	/// Recursively searches for the first child element of type <typeparamref name="T"/> in the UIElement hierarchy, starting from <paramref name="parent"/>.
+	/// An optional predicate can be provided to filter results based on custom logic.
+	/// Returns the first match found in a depth-first search, or <c>null</c> if no matching element is found.
+	/// </summary>
+	/// <typeparam name="T">The specific UIElement-derived type to search for.</typeparam>
+	/// <param name="parent">The UIElement to begin the search from.</param>
+	/// <param name="predicate">An optional filter function to further restrict matching elements.</param>
+	/// <returns>The first matching child element of type <typeparamref name="T"/>, or <c>null</c> if none found.</returns>
+	internal static T? FindChildOfType<T>(UIElement parent, Func<T, bool>? predicate = null)
+		where T : UIElement
+	{
+		foreach (var child in parent.Children)
+		{
+			if (child is T tChild && (predicate?.Invoke(tChild) ?? true))
+			{
+				return tChild;
+			}
+			var found = FindChildOfType(child, predicate);
+			if (found != null)
+			{
+				return found;
+			}
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds a button to the mod's configuration menu that lets users open the keybindings menu and automatically scrolls to this mod’s section. The button works both in the main menu and in-game.

## Changes
- Added `OpenKeybindingsMenuButton` config element, which opens the keybindings UI and scrolls directly to the mod's controls section.
- Introduced `UIElementHelpers`, providing methods for recursively finding and collecting UI elements by type within the UI hierarchy.

## Demo
https://github.com/user-attachments/assets/5e065d6f-48a2-41e1-9d71-22f34ec573ab

### Closes #150