### PR TITLE
fix: canonicalize item types for `Shellphone` variants

### DIFF
--- a/RecipeCatalogueUI.cs
+++ b/RecipeCatalogueUI.cs
@@ -598,7 +598,7 @@ namespace RecipeBrowser
 
 			if (!queryItem.item.IsAir)
 			{
-				int type = queryItem.NormalizedItemType;
+				int type = queryItem.CanonicalItemType;
 				bool inGroup = recipe.acceptedGroups.Intersect(groups).Any(); // Lesion item bug, they have the Wood group but don't have any wood in them
 				
 				if (!inGroup)

--- a/RecipeCatalogueUI.cs
+++ b/RecipeCatalogueUI.cs
@@ -598,7 +598,7 @@ namespace RecipeBrowser
 
 			if (!queryItem.item.IsAir)
 			{
-				int type = queryItem.item.type;
+				int type = queryItem.NormalizedItemType;
 				bool inGroup = recipe.acceptedGroups.Intersect(groups).Any(); // Lesion item bug, they have the Wood group but don't have any wood in them
 				
 				if (!inGroup)

--- a/UIElements/UIQueryItemSlot.cs
+++ b/UIElements/UIQueryItemSlot.cs
@@ -27,18 +27,18 @@ namespace RecipeBrowser.UIElements
 		}
 
 		/// <summary>
-		/// Gets the normalized Terraria <see cref="Item.type"/> for the current slot item.
-		/// Returns <c>0</c> if the slot is empty.
+		/// Gets the canonical Terraria <see cref="Item.type"/> for the current slot item.
+		/// Returns <see cref="ItemID.None"/> if the slot is empty.
 		/// </summary>
-		internal int NormalizedItemType
+		internal int CanonicalItemType
 		{
 			get
 			{
-				int type = item?.type ?? 0;
+				int type = item?.type ?? ItemID.None;
 				return type switch
 				{
-					ItemID.Shellphone or ItemID.ShellphoneSpawn or ItemID.ShellphoneOcean or ItemID.ShellphoneHell
-						=> ItemID.ShellphoneDummy,
+					ItemID.Shellphone or ItemID.ShellphoneSpawn or ItemID.ShellphoneOcean or ItemID.ShellphoneHell =>
+						ItemID.ShellphoneDummy,
 					_ => type,
 				};
 			}

--- a/UIElements/UIQueryItemSlot.cs
+++ b/UIElements/UIQueryItemSlot.cs
@@ -39,7 +39,15 @@ namespace RecipeBrowser.UIElements
 				{
 					ItemID.Shellphone or ItemID.ShellphoneSpawn or ItemID.ShellphoneOcean or ItemID.ShellphoneHell =>
 						ItemID.ShellphoneDummy,
+					ItemID.DontHurtCrittersBookInactive => ItemID.DontHurtCrittersBook,
+					ItemID.DontHurtNatureBookInactive => ItemID.DontHurtNatureBook,
+					ItemID.DontHurtComboBookInactive => ItemID.DontHurtComboBook,
+					ItemID.ClosedVoidBag => ItemID.VoidLens,
+					ItemID.UncumberingStone => ItemID.EncumberingStone,
+					ItemID.RubblemakerLarge or ItemID.RubblemakerMedium => ItemID.RubblemakerSmall,
 					_ => type,
+					// From Player.ItemCheck_ManageRightClickFeatures.
+					// TODO: We might also want to consider using ItemID.Sets.ShimmerCountsAsItem or Item.GetShimmerEquivalentType to handle modded items with a similar design as well. Modded items probably shouldn't be using the separate Item type approach anyway though.
 				};
 			}
 		}

--- a/UIElements/UIQueryItemSlot.cs
+++ b/UIElements/UIQueryItemSlot.cs
@@ -26,6 +26,24 @@ namespace RecipeBrowser.UIElements
 		{
 		}
 
+		/// <summary>
+		/// Gets the normalized Terraria <see cref="Item.type"/> for the current slot item.
+		/// Returns <c>0</c> if the slot is empty.
+		/// </summary>
+		internal int NormalizedItemType
+		{
+			get
+			{
+				int type = item?.type ?? 0;
+				return type switch
+				{
+					ItemID.Shellphone or ItemID.ShellphoneSpawn or ItemID.ShellphoneOcean or ItemID.ShellphoneHell
+						=> ItemID.ShellphoneDummy,
+					_ => type,
+				};
+			}
+		}
+		
 		protected override void DrawSelf(SpriteBatch spriteBatch)
 		{
 			base.DrawSelf(spriteBatch);


### PR DESCRIPTION
## Summary
Shell phone has multiple usage modes that swap its `Item.type` to variant IDs. When the query uses those live variant types, recipes for them do not appear in the recipe catalogue. 

The visual item shown in the slot does not change; only the internal query type is canonicalized.

## Changes
- Added `CanonicalItemType` property in `UIQueryItemSlot`, which returns the canonical Terraria `Item.type` (returns `ItemID.None` when the slot is empty).
- Mapped `Shellphone`, `ShellphoneSpawn`, `ShellphoneOcean`, and `ShellphoneHell` to `ShellphoneDummy`.
- Updated `PassRecipeFilters` to use the canonical item type.

### Fixes #189