### PR TITLE
feat: add dropdown for mod selection

### DIFF
--- a/RecipeBrowserUI.cs
+++ b/RecipeBrowserUI.cs
@@ -424,17 +424,20 @@ namespace RecipeBrowser
 			return index == 0 ? RBText("All") : ModLoader.GetMod(mods[index]).DisplayName;
 		}
 
-		private void UpdateModHoverImage(UIHoverImageButtonMod button)
+		private void UpdateModHoverImage(UIHoverImageButtonMod btn)
 		{
-			button.texture = null;
+			btn.texture = null;
 			Mod otherMod = ModLoader.GetMod(mods[modIndex]);
-			if (otherMod != null && otherMod.FileExists("icon.png"))
+			if (otherMod == null || !otherMod.FileExists("icon.png"))
 			{
-				var modIconTexture = Texture2D.FromStream(Main.instance.GraphicsDevice, new MemoryStream(otherMod.GetFileBytes("icon.png")));
-				if (modIconTexture.Width == 80 && modIconTexture.Height == 80)
-				{
-					button.texture = modIconTexture;
-				}
+				return;
+			}
+			
+			using var ms = new MemoryStream(otherMod.GetFileBytes("icon.png"));
+			var modIconTexture = Texture2D.FromStream(Main.instance.GraphicsDevice, ms);
+			if (modIconTexture.Width == 80 && modIconTexture.Height == 80)
+			{
+				btn.texture = modIconTexture;
 			}
 		}
 

--- a/RecipeBrowserUI.cs
+++ b/RecipeBrowserUI.cs
@@ -376,15 +376,8 @@ namespace RecipeBrowser
 					UpdateModFilterUI(filterButtonAtCreation);
 				};
 			}
-			
-			if (ModFilterDropdown.IsAttachedTo(host))
-			{
-				ModFilterDropdown.Detach();
-				return;
-			}
-			
-			ModFilterDropdown.Detach();
-			ModFilterDropdown.AttachTo(host);
+
+			Terraria.ModLoader.UI.UICommon.AddOrRemoveChild(host, ModFilterDropdown, ModFilterDropdown.Parent == null);
 		}
 
 		private void ModFilterButton_OnRightClick(UIMouseEvent evt, UIElement listeningElement)
@@ -720,10 +713,7 @@ namespace RecipeBrowser
 				parent.Append(panels[panelIndex]);
 				parent.Append(buttons[panelIndex]);
 
-				if (
-					RecipeBrowserUI.instance.ModFilterDropdown != null
-					&& RecipeBrowserUI.instance.ModFilterDropdown.IsAttachedTo(parent)
-				)
+				if (RecipeBrowserUI.instance.ModFilterDropdown?.Parent == parent)
 				{
 					parent.RemoveChild(RecipeBrowserUI.instance.ModFilterDropdown);
 					parent.Append(RecipeBrowserUI.instance.ModFilterDropdown);

--- a/RecipeBrowserUI.cs
+++ b/RecipeBrowserUI.cs
@@ -54,6 +54,7 @@ namespace RecipeBrowser
 		internal bool[] foundItems;
 
 		internal string[] mods;
+		internal ModFilterDropdown ModFilterDropdown;
 
 		public bool ForceShowFavoritePanel;
 		public bool ForceHideFavoritePanel; // Could save to config on exit world to preserve, but if users want that they should just not favorite recipes.
@@ -345,10 +346,53 @@ namespace RecipeBrowser
 
 		private void ModFilterButton_OnClick(UIMouseEvent evt, UIElement listeningElement)
 		{
-			UIHoverImageButtonMod button = (evt.Target as UIHoverImageButtonMod);
-			button.hoverText = RBText("ModFilter") + ": " + GetModFilterTooltip(true);
-			UpdateModHoverImage(button);
-			AllUpdateNeeded();
+			if (mods.Length < 4)
+			{
+				UpdateFilterUI((UIHoverImageButtonMod)evt.Target);
+				return;
+			}
+
+			var host = listeningElement.Parent?.Parent;
+			if (host == null)
+			{
+				return;
+			}
+			
+			if (ModFilterDropdown == null)
+			{
+				var filterButtonAtCreation = (UIHoverImageButtonMod)listeningElement;
+
+				ModFilterDropdown = new ModFilterDropdown(
+					mods,
+					modIndex,
+					i => i == 0 ? RBText("All") : (ModLoader.GetMod(mods[i])?.DisplayName ?? mods[i])
+				);
+
+				ModFilterDropdown.SelectedIndexChanged += (_, selectedIndex) =>
+				{
+					modIndex = selectedIndex;
+					UpdateFilterUI(filterButtonAtCreation);
+				};
+			}
+			
+			if (ModFilterDropdown.IsAttachedTo(host))
+			{
+				ModFilterDropdown.Detach();
+				return;
+			}
+			
+			ModFilterDropdown.Detach();
+			ModFilterDropdown.AttachTo(host);
+			return;
+
+			void UpdateFilterUI(UIHoverImageButtonMod btn)
+			{
+				btn.hoverText = RBText("ModFilter") + ": " +
+				                (modIndex == 0 ? RBText("All") : ModLoader.GetMod(mods[modIndex]).DisplayName);
+
+				UpdateModHoverImage(btn);
+				AllUpdateNeeded();
+			}
 		}
 
 		private void ModFilterButton_OnRightClick(UIMouseEvent evt, UIElement listeningElement)
@@ -665,6 +709,15 @@ namespace RecipeBrowser
 				parent.Append(panels[panelIndex]);
 				parent.Append(buttons[panelIndex]);
 
+				if (
+					RecipeBrowserUI.instance.ModFilterDropdown != null
+					&& RecipeBrowserUI.instance.ModFilterDropdown.IsAttachedTo(parent)
+				)
+				{
+					parent.RemoveChild(RecipeBrowserUI.instance.ModFilterDropdown);
+					parent.Append(RecipeBrowserUI.instance.ModFilterDropdown);
+				}
+				
 				if(panelIndex == RecipeBrowserUI.ItemCatalogue)
 				{
 					SharedUI.instance.sortsAndFiltersPanel.Top.Set(0, 0f);

--- a/RecipeBrowserUI.cs
+++ b/RecipeBrowserUI.cs
@@ -348,7 +348,14 @@ namespace RecipeBrowser
 		{
 			if (mods.Length < 4)
 			{
-				UpdateFilterUI((UIHoverImageButtonMod)evt.Target);
+				var btn = (UIHoverImageButtonMod)evt.Target;
+
+				if (mods.Length > 1)
+				{
+					modIndex = (modIndex + 1) % mods.Length;
+				}
+
+				UpdateFilterUI(btn);
 				return;
 			}
 

--- a/RecipeBrowserUI.cs
+++ b/RecipeBrowserUI.cs
@@ -349,13 +349,8 @@ namespace RecipeBrowser
 			if (mods.Length < 4)
 			{
 				var btn = (UIHoverImageButtonMod)evt.Target;
-
-				if (mods.Length > 1)
-				{
-					modIndex = (modIndex + 1) % mods.Length;
-				}
-
-				UpdateFilterUI(btn);
+				ChangeModIndex(true);
+				UpdateModFilterUI(btn);
 				return;
 			}
 
@@ -372,13 +367,13 @@ namespace RecipeBrowser
 				ModFilterDropdown = new ModFilterDropdown(
 					mods,
 					modIndex,
-					i => i == 0 ? RBText("All") : (ModLoader.GetMod(mods[i])?.DisplayName ?? mods[i])
+					GetDisplayName
 				);
 
 				ModFilterDropdown.SelectedIndexChanged += (_, selectedIndex) =>
 				{
 					modIndex = selectedIndex;
-					UpdateFilterUI(filterButtonAtCreation);
+					UpdateModFilterUI(filterButtonAtCreation);
 				};
 			}
 			
@@ -390,33 +385,43 @@ namespace RecipeBrowser
 			
 			ModFilterDropdown.Detach();
 			ModFilterDropdown.AttachTo(host);
-			return;
-
-			void UpdateFilterUI(UIHoverImageButtonMod btn)
-			{
-				btn.hoverText = RBText("ModFilter") + ": " +
-				                (modIndex == 0 ? RBText("All") : ModLoader.GetMod(mods[modIndex]).DisplayName);
-
-				UpdateModHoverImage(btn);
-				AllUpdateNeeded();
-			}
 		}
 
 		private void ModFilterButton_OnRightClick(UIMouseEvent evt, UIElement listeningElement)
 		{
-			UIHoverImageButtonMod button = (evt.Target as UIHoverImageButtonMod);
-			button.hoverText = RBText("ModFilter") + ": " + GetModFilterTooltip(false);
-			UpdateModHoverImage(button);
-			AllUpdateNeeded();
+			UIHoverImageButtonMod btn = (evt.Target as UIHoverImageButtonMod);
+			ChangeModIndex(false);
+			UpdateModFilterUI(btn);
 		}
 
 		private void ModFilterButton_OnMiddleClick(UIMouseEvent evt, UIElement listeningElement)
 		{
-			UIHoverImageButtonMod button = (evt.Target as UIHoverImageButtonMod);
+			UIHoverImageButtonMod btn = (evt.Target as UIHoverImageButtonMod);
 			modIndex = 0;
-			button.hoverText = RBText("ModFilter") + ": " + RBText("All");
-			UpdateModHoverImage(button);
+			UpdateModFilterUI(btn);
+		}
+
+		private void UpdateModFilterUI(UIHoverImageButtonMod btn)
+		{
+			btn.hoverText = RBText("ModFilter") + ": " + GetDisplayName(modIndex);
+			UpdateModHoverImage(btn);
 			AllUpdateNeeded();
+		}
+
+		private void ChangeModIndex(bool increment)
+		{
+			if (mods.Length <= 1)
+			{
+				modIndex = 0;
+				return;
+			}
+			
+			modIndex = (modIndex + (increment ? 1 : mods.Length - 1)) % mods.Length;
+		}
+
+		private string GetDisplayName(int index)
+		{
+			return index == 0 ? RBText("All") : ModLoader.GetMod(mods[index]).DisplayName;
 		}
 
 		private void UpdateModHoverImage(UIHoverImageButtonMod button)
@@ -431,12 +436,6 @@ namespace RecipeBrowser
 					button.texture = modIconTexture;
 				}
 			}
-		}
-
-		private string GetModFilterTooltip(bool increment)
-		{
-			modIndex = increment ? (modIndex + 1) % mods.Length : (mods.Length + modIndex - 1) % mods.Length;
-			return modIndex == 0 ? RBText("All") : ModLoader.GetMod(mods[modIndex]).DisplayName;
 		}
 
 		internal void AllUpdateNeeded()

--- a/RecipeBrowserUI.cs
+++ b/RecipeBrowserUI.cs
@@ -391,6 +391,7 @@ namespace RecipeBrowser
 		{
 			UIHoverImageButtonMod btn = (evt.Target as UIHoverImageButtonMod);
 			ChangeModIndex(false);
+			ModFilterDropdown?.SelectIndex(modIndex);
 			UpdateModFilterUI(btn);
 		}
 
@@ -398,6 +399,7 @@ namespace RecipeBrowser
 		{
 			UIHoverImageButtonMod btn = (evt.Target as UIHoverImageButtonMod);
 			modIndex = 0;
+			ModFilterDropdown?.SelectIndex(modIndex);
 			UpdateModFilterUI(btn);
 		}
 

--- a/RecipeBrowserUI.cs
+++ b/RecipeBrowserUI.cs
@@ -42,6 +42,9 @@ namespace RecipeBrowser
 		internal UIElements.UICycleImage ShowOtherPlayersFavoritesToggle;
 		internal UIHoverImageButton closeFavoritePanelButton;
 		internal UIHoverImageButton closeButton;
+		internal UIHoverImageButtonMod modFilterButton;
+		private BlockInputElement blockInput;
+		private UIElement activeDialog;
 
 		//internal SharedUI sharedUI;
 		internal RecipeCatalogueUI recipeCatalogueUI;
@@ -268,7 +271,7 @@ namespace RecipeBrowser
 
 			Asset<Texture2D> filterModTexture = RecipeBrowser.instance.Assets.Request<Texture2D>(RBText("FilterMod", "ImagePaths"), AssetRequestMode.ImmediateLoad);
 			Asset<Texture2D> filterModColorableTexture = RecipeBrowser.instance.Assets.Request<Texture2D>(RBText("FilterModColorable", "ImagePaths"), AssetRequestMode.ImmediateLoad);
-			var modFilterButton = new UIHoverImageButtonMod(filterModTexture, filterModColorableTexture, RBText("ModFilter") + ": " + RBText("All"));
+			modFilterButton = new UIHoverImageButtonMod(filterModTexture, filterModColorableTexture, RBText("ModFilter") + ": " + RBText("All"));
 			modFilterButton.Left.Set(-60, 1f);
 			modFilterButton.Top.Set(-0, 0f);
 			modFilterButton.OnLeftClick += ModFilterButton_OnClick;
@@ -342,15 +345,16 @@ namespace RecipeBrowser
 		//}
 
 		// Vanilla ModLoader mod will act as "all"
-		internal static int modIndex;
+		internal static int modIndex; // Selected mod
+		internal static int modIndexPrevious; // Last icon calculated
+		internal static int modHoverIndex = -1; // Currently hovering option
 
 		private void ModFilterButton_OnClick(UIMouseEvent evt, UIElement listeningElement)
 		{
 			if (mods.Length < 4)
 			{
-				var btn = (UIHoverImageButtonMod)evt.Target;
 				ChangeModIndex(true);
-				UpdateModFilterUI(btn);
+				UpdateModFilterUI();
 				return;
 			}
 
@@ -362,8 +366,6 @@ namespace RecipeBrowser
 			
 			if (ModFilterDropdown == null)
 			{
-				var filterButtonAtCreation = (UIHoverImageButtonMod)listeningElement;
-
 				ModFilterDropdown = new ModFilterDropdown(
 					mods,
 					modIndex,
@@ -373,33 +375,35 @@ namespace RecipeBrowser
 				ModFilterDropdown.SelectedIndexChanged += (_, selectedIndex) =>
 				{
 					modIndex = selectedIndex;
-					UpdateModFilterUI(filterButtonAtCreation);
+					UpdateModFilterUI();
+					UnblockInput(evt, listeningElement);
 				};
 			}
 
-			Terraria.ModLoader.UI.UICommon.AddOrRemoveChild(host, ModFilterDropdown, ModFilterDropdown.Parent == null);
+			if(ModFilterDropdown.Parent == null)
+				BlockInput(ModFilterDropdown);
+			else
+				UnblockInput(evt, listeningElement);
 		}
 
 		private void ModFilterButton_OnRightClick(UIMouseEvent evt, UIElement listeningElement)
 		{
-			UIHoverImageButtonMod btn = (evt.Target as UIHoverImageButtonMod);
 			ChangeModIndex(false);
 			ModFilterDropdown?.SelectIndex(modIndex);
-			UpdateModFilterUI(btn);
+			UpdateModFilterUI();
 		}
 
 		private void ModFilterButton_OnMiddleClick(UIMouseEvent evt, UIElement listeningElement)
 		{
-			UIHoverImageButtonMod btn = (evt.Target as UIHoverImageButtonMod);
 			modIndex = 0;
 			ModFilterDropdown?.SelectIndex(modIndex);
-			UpdateModFilterUI(btn);
+			UpdateModFilterUI();
 		}
 
-		private void UpdateModFilterUI(UIHoverImageButtonMod btn)
+		private void UpdateModFilterUI()
 		{
-			btn.hoverText = RBText("ModFilter") + ": " + GetDisplayName(modIndex);
-			UpdateModHoverImage(btn);
+			modFilterButton.hoverText = RBText("ModFilter") + ": " + GetDisplayName(modIndex);
+			UpdateModHoverImage();
 			AllUpdateNeeded();
 		}
 
@@ -419,10 +423,15 @@ namespace RecipeBrowser
 			return index == 0 ? RBText("All") : ModLoader.GetMod(mods[index]).DisplayName;
 		}
 
-		private void UpdateModHoverImage(UIHoverImageButtonMod btn)
+		internal void UpdateModHoverImage()
 		{
-			btn.texture = null;
-			Mod otherMod = ModLoader.GetMod(mods[modIndex]);
+			int indexToDisplay = modHoverIndex > -1 ? modHoverIndex : modIndex;
+			if (indexToDisplay == modIndexPrevious)
+				return;
+
+			modIndexPrevious = indexToDisplay;
+			modFilterButton.texture = null;
+			Mod otherMod = ModLoader.GetMod(mods[indexToDisplay]);
 			if (otherMod == null || !otherMod.FileExists("icon.png"))
 			{
 				return;
@@ -432,7 +441,7 @@ namespace RecipeBrowser
 			var modIconTexture = Texture2D.FromStream(Main.instance.GraphicsDevice, ms);
 			if (modIconTexture.Width == 80 && modIconTexture.Height == 80)
 			{
-				btn.texture = modIconTexture;
+				modFilterButton.texture = modIconTexture;
 			}
 		}
 
@@ -666,6 +675,20 @@ namespace RecipeBrowser
 				}
 			}
 			npcArrow = -1;
+		}
+
+		internal void BlockInput(UIElement dialog) {
+			blockInput = new BlockInputElement(mainPanel, 20);
+			blockInput.OnLeftMouseDown += UnblockInput;
+			mainPanel.Append(blockInput);
+			mainPanel.Append(activeDialog = dialog);
+		}
+
+		internal void UnblockInput(UIMouseEvent evt, UIElement listeningElement) {
+			blockInput?.Remove();
+			activeDialog?.Remove();
+
+			UpdateModHoverImage();
 		}
 	}
 

--- a/UIElements/BlockInputElement.cs
+++ b/UIElements/BlockInputElement.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria;
+using Terraria.GameContent;
+using Terraria.UI;
+
+namespace RecipeBrowser.UIElements
+{
+	internal class BlockInputElement : UIElement
+	{
+		private UIElement elementToBlock;
+		private int top;
+
+		public BlockInputElement(UIElement elementToBlock, int top) {
+			Width.Set(0, 1);
+			Height.Set(0, 1);
+			//Height.Set(-top, 1);
+			//Top.Set(top, 0);
+
+			this.top = top;
+			this.elementToBlock = elementToBlock;
+		}
+
+		protected override void DrawSelf(SpriteBatch spriteBatch) {
+			var drawArea = elementToBlock.GetDimensions().ToRectangle();
+			drawArea.Y += top;
+			drawArea.Height -= top;
+			//spriteBatch.Draw(TextureAssets.MagicPixel.Value, drawArea, Color.Black * 0.5f);
+			Utils.DrawInvBG(spriteBatch, drawArea, Color.Black * 0.5f);
+		}
+	}
+}

--- a/UIElements/ModFilterDropdown.cs
+++ b/UIElements/ModFilterDropdown.cs
@@ -12,7 +12,7 @@ namespace RecipeBrowser.UIElements;
 
 internal sealed class ModFilterDropdown : UIPanel
 {
-	private const float PanelWidth = 230f;
+	private const float PanelWidth = 300f;
 	private const float Pad = 6f;
 	private const float ListPad = 4f;
 	private const float TopCoverBar = 2f;
@@ -21,13 +21,12 @@ internal sealed class ModFilterDropdown : UIPanel
 	private readonly Func<int, string> _getDisplayName;
 	private readonly List<ModFilterDropdownRow> _rows = [];
 
-	internal ModFilterDropdown(string[] mods, int selectedIndex, Func<int, string> getDisplayName)
-	{
+	internal ModFilterDropdown(string[] mods, int selectedIndex, Func<int, string> getDisplayName) {
 		_mods = mods ?? [];
 		_getDisplayName = getDisplayName ?? (_ => string.Empty);
 
 		Width.Set(PanelWidth, 0f);
-		Height.Set(-165f, 1f);
+		Height.Set(-50f, 1f);
 		Top.Set(20f, 0f);
 		Left.Set(-PanelWidth, 1f);
 		SetPadding(Pad);
@@ -38,10 +37,8 @@ internal sealed class ModFilterDropdown : UIPanel
 
 	internal event EventHandler<int> SelectedIndexChanged;
 
-	internal void SelectIndex(int index)
-	{
-		if (_rows.Count == 0)
-		{
+	internal void SelectIndex(int index) {
+		if (_rows.Count == 0) {
 			return;
 		}
 
@@ -49,11 +46,9 @@ internal sealed class ModFilterDropdown : UIPanel
 		OnRowSelected(clamped);
 	}
 
-	private void BuildContent(int selectedIndex)
-	{
-		var inner = new UIPanel
-		{
-			Width = { Pixels = -24f, Percent = 1f },
+	private void BuildContent(int selectedIndex) {
+		var inner = new UIPanel {
+			Width = { Pixels = 0, Percent = 1f },
 			Height = { Pixels = 0f, Percent = 1f },
 			Top = { Pixels = 0f, Percent = 0f },
 			BackgroundColor = new Color(200, 50, 50, 255),
@@ -61,16 +56,14 @@ internal sealed class ModFilterDropdown : UIPanel
 		inner.SetPadding(Pad);
 		Append(inner);
 
-		var list = new UIList
-		{
+		var list = new UIList {
 			Width = { Pixels = 0f, Percent = 1f },
 			Height = { Pixels = 0f, Percent = 1f },
 			ListPadding = ListPad,
 		};
 		inner.Append(list);
 
-		var scrollbar = new UIScrollbar
-		{
+		var scrollbar = new InvisibleFixedUIScrollbar(RecipeBrowserUI.instance.userInterface) {
 			Height = { Pixels = -12f, Percent = 1f },
 			Top = { Pixels = Pad, Percent = 0f },
 			HAlign = 1f,
@@ -78,21 +71,18 @@ internal sealed class ModFilterDropdown : UIPanel
 		list.SetScrollbar(scrollbar);
 		Append(scrollbar);
 
-		for (int i = 0; i < _mods.Length; i++)
-		{
+		for (int i = 0; i < _mods.Length; i++) {
 			string text = _getDisplayName(i);
 			var row = new ModFilterDropdownRow(i, text, selectedIndex == i, OnRowSelected);
 			_rows.Add(row);
 			list.Add(row);
 		}
 
-		if (_rows.Count > 1)
-		{
+		if (_rows.Count > 1) {
 			_rows[^1].MarginBottom = -list.ListPadding;
 		}
 
-		var topCover = new UIImage(TextureAssets.MagicPixel)
-		{
+		var topCover = new UIImage(TextureAssets.MagicPixel) {
 			IgnoresMouseInteraction = true,
 			Color = BackgroundColor,
 			ScaleToFit = true,
@@ -106,10 +96,8 @@ internal sealed class ModFilterDropdown : UIPanel
 		OnRowSelected(selectedIndex);
 	}
 
-	private void OnRowSelected(int index)
-	{
-		for (int i = 0; i < _rows.Count; i++)
-		{
+	private void OnRowSelected(int index) {
+		for (int i = 0; i < _rows.Count; i++) {
 			_rows[i].SetSelected(i == index);
 		}
 
@@ -122,15 +110,14 @@ internal sealed class ModFilterDropdown : UIPanel
 
 		private readonly string _fullText;
 		private readonly UIText _label;
-		
+
 		private bool _selected;
 		private bool _hasComputedTruncation;
 		private bool _isTruncated;
 
 		private int Index { get; }
 
-		internal ModFilterDropdownRow(int index, string displayText, bool selected, Action<int> onSelect)
-		{
+		internal ModFilterDropdownRow(int index, string displayText, bool selected, Action<int> onSelect) {
 			_fullText = displayText;
 			_selected = selected;
 			Index = index;
@@ -142,10 +129,8 @@ internal sealed class ModFilterDropdown : UIPanel
 			Append(_label);
 
 			OnLeftClick += (_, _) => onSelect?.Invoke(Index);
-			OnMouseOver += (_, _) =>
-			{
-				if (!_selected)
-				{
+			OnMouseOver += (_, _) => {
+				if (!_selected) {
 					BackgroundColor = Color.DarkRed * 0.3f;
 					BorderColor = Color.DarkRed * 0.3f;
 				}
@@ -155,79 +140,71 @@ internal sealed class ModFilterDropdown : UIPanel
 			Refresh();
 		}
 
-		internal void SetSelected(bool selected)
-		{
+		internal void SetSelected(bool selected) {
 			_selected = selected;
 			Refresh();
 		}
 
-		protected override void DrawSelf(SpriteBatch spriteBatch)
-		{
+		protected override void DrawSelf(SpriteBatch spriteBatch) {
 			base.DrawSelf(spriteBatch);
-			
-			if (!_hasComputedTruncation)
-			{
+
+			if (!_hasComputedTruncation) {
 				ComputeTruncationOnce();
 				_hasComputedTruncation = true;
 			}
-			
-			if (_isTruncated && IsMouseHovering)
-			{
+
+			if (_isTruncated && IsMouseHovering) {
 				UICommon.TooltipMouseText(_fullText);
 			}
+			if (IsMouseHovering) {
+				RecipeBrowserUI.modHoverIndex = Index;
+				RecipeBrowserUI.instance.UpdateModHoverImage();
+			}
 		}
-		
-		private void Refresh()
-		{
+
+		private void Refresh() {
 			BackgroundColor = _selected ? Color.DarkRed : Color.Transparent;
 			BorderColor = _selected ? Color.DarkRed : Color.Transparent;
 		}
-		
-		private void ComputeTruncationOnce()
-		{
+
+		private void ComputeTruncationOnce() {
 			float availablePx = GetInnerDimensions().Width;
-			if (availablePx <= 0f)
-			{
+			if (availablePx <= 0f) {
 				_label.SetText(string.Empty);
 				_isTruncated = true;
 				return;
 			}
-			
+
 			DynamicSpriteFont font = FontAssets.MouseText.Value;
 			float maxUnits = availablePx / TextScale;
-			
+
 			float fullUnits = font.MeasureString(_fullText).X;
-			if (fullUnits <= maxUnits)
-			{
+			if (fullUnits <= maxUnits) {
 				_label.SetText(_fullText);
 				_isTruncated = false;
 				return;
 			}
-			
+
 			const string ellipsis = "...";
 			float ellipsisUnits = font.MeasureString(ellipsis).X;
-			if (ellipsisUnits > maxUnits)
-			{
+			if (ellipsisUnits > maxUnits) {
 				_label.SetText(string.Empty);
 				_isTruncated = true;
 				return;
 			}
-			
+
 			int minLength = 0, maxLength = _fullText.Length;
-			while (minLength < maxLength)
-			{
+			while (minLength < maxLength) {
 				int candidateLength = (minLength + maxLength + 1) >> 1;
 				float units = font.MeasureString(_fullText[..candidateLength]).X + ellipsisUnits;
-				if (units <= maxUnits)
-				{
+				if (units <= maxUnits) {
 					minLength = candidateLength;
 				}
-				else
-				{
+				else {
 					maxLength = candidateLength - 1;
 				}
 			}
-			
+
 			_label.SetText(_fullText[..minLength] + ellipsis);
 			_isTruncated = true;
 		}

--- a/UIElements/ModFilterDropdown.cs
+++ b/UIElements/ModFilterDropdown.cs
@@ -21,7 +21,7 @@ internal sealed class ModFilterDropdown : UIPanel
 	private readonly Func<int, string> _getDisplayName;
 	private readonly List<ModFilterDropdownRow> _rows = [];
 
-	public ModFilterDropdown(string[] mods, int selectedIndex, Func<int, string> getDisplayName)
+	internal ModFilterDropdown(string[] mods, int selectedIndex, Func<int, string> getDisplayName)
 	{
 		_mods = mods ?? [];
 		_getDisplayName = getDisplayName ?? (_ => string.Empty);
@@ -36,9 +36,9 @@ internal sealed class ModFilterDropdown : UIPanel
 		BuildContent(selectedIndex);
 	}
 
-	public event EventHandler<int> SelectedIndexChanged;
+	internal event EventHandler<int> SelectedIndexChanged;
 
-	public void SelectIndex(int index)
+	internal void SelectIndex(int index)
 	{
 		if (_rows.Count == 0)
 		{
@@ -49,11 +49,11 @@ internal sealed class ModFilterDropdown : UIPanel
 		OnRowSelected(clamped);
 	}
 
-	public void AttachTo(UIElement parent) => parent?.Append(this);
+	internal void AttachTo(UIElement parent) => parent?.Append(this);
 
-	public void Detach() => Parent?.RemoveChild(this);
+	internal void Detach() => Parent?.RemoveChild(this);
 
-	public bool IsAttachedTo(UIElement parent) => Parent == parent;
+	internal bool IsAttachedTo(UIElement parent) => Parent == parent;
 
 	private void BuildContent(int selectedIndex)
 	{
@@ -135,7 +135,7 @@ internal sealed class ModFilterDropdown : UIPanel
 
 		private int Index { get; }
 
-		public ModFilterDropdownRow(int index, string displayText, bool selected, Action<int> onSelect)
+		internal ModFilterDropdownRow(int index, string displayText, bool selected, Action<int> onSelect)
 		{
 			_fullText = displayText;
 			_selected = selected;
@@ -161,7 +161,7 @@ internal sealed class ModFilterDropdown : UIPanel
 			Refresh();
 		}
 
-		public void SetSelected(bool selected)
+		internal void SetSelected(bool selected)
 		{
 			_selected = selected;
 			Refresh();

--- a/UIElements/ModFilterDropdown.cs
+++ b/UIElements/ModFilterDropdown.cs
@@ -49,12 +49,6 @@ internal sealed class ModFilterDropdown : UIPanel
 		OnRowSelected(clamped);
 	}
 
-	internal void AttachTo(UIElement parent) => parent?.Append(this);
-
-	internal void Detach() => Parent?.RemoveChild(this);
-
-	internal bool IsAttachedTo(UIElement parent) => Parent == parent;
-
 	private void BuildContent(int selectedIndex)
 	{
 		var inner = new UIPanel

--- a/UIElements/ModFilterDropdown.cs
+++ b/UIElements/ModFilterDropdown.cs
@@ -38,6 +38,17 @@ internal sealed class ModFilterDropdown : UIPanel
 
 	public event EventHandler<int> SelectedIndexChanged;
 
+	public void SelectIndex(int index)
+	{
+		if (_rows.Count == 0)
+		{
+			return;
+		}
+
+		int clamped = Math.Clamp(index, 0, _rows.Count - 1);
+		OnRowSelected(clamped);
+	}
+
 	public void AttachTo(UIElement parent) => parent?.Append(this);
 
 	public void Detach() => Parent?.RemoveChild(this);

--- a/UIElements/ModFilterDropdown.cs
+++ b/UIElements/ModFilterDropdown.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Terraria.GameContent;
+using Terraria.GameContent.UI.Elements;
+using Terraria.UI;
+
+namespace RecipeBrowser.UIElements;
+
+internal sealed class ModFilterDropdown : UIPanel
+{
+	private const float PanelWidth = 230f;
+	private const float Pad = 6f;
+	private const float ListPad = 4f;
+	private const float TopCoverBar = 2f;
+
+	private readonly string[] _mods;
+	private readonly Func<int, string> _getDisplayName;
+	private readonly List<ModFilterDropdownRow> _rows = [];
+
+	public ModFilterDropdown(string[] mods, int selectedIndex, Func<int, string> getDisplayName)
+	{
+		_mods = mods ?? [];
+		_getDisplayName = getDisplayName ?? (_ => string.Empty);
+
+		Width.Set(PanelWidth, 0f);
+		Height.Set(-165f, 1f);
+		Top.Set(20f, 0f);
+		Left.Set(-PanelWidth, 1f);
+		SetPadding(Pad);
+		BackgroundColor = Color.DarkRed;
+
+		BuildContent(selectedIndex);
+	}
+
+	public event EventHandler<int> SelectedIndexChanged;
+
+	public void AttachTo(UIElement parent) => parent?.Append(this);
+
+	public void Detach() => Parent?.RemoveChild(this);
+
+	public bool IsAttachedTo(UIElement parent) => Parent == parent;
+
+	private void BuildContent(int selectedIndex)
+	{
+		var inner = new UIPanel
+		{
+			Width = { Pixels = -24f, Percent = 1f },
+			Height = { Pixels = 0f, Percent = 1f },
+			Top = { Pixels = 0f, Percent = 0f },
+			BackgroundColor = new Color(200, 50, 50, 255),
+		};
+		inner.SetPadding(Pad);
+		Append(inner);
+
+		var list = new UIList
+		{
+			Width = { Pixels = 0f, Percent = 1f },
+			Height = { Pixels = 0f, Percent = 1f },
+			ListPadding = ListPad,
+		};
+		inner.Append(list);
+
+		var scrollbar = new UIScrollbar
+		{
+			Height = { Pixels = -12f, Percent = 1f },
+			Top = { Pixels = Pad, Percent = 0f },
+			HAlign = 1f,
+		};
+		list.SetScrollbar(scrollbar);
+		Append(scrollbar);
+
+		for (int i = 0; i < _mods.Length; i++)
+		{
+			string text = _getDisplayName(i);
+			var row = new ModFilterDropdownRow(i, text, selectedIndex == i, OnRowSelected);
+			_rows.Add(row);
+			list.Add(row);
+		}
+
+		if (_rows.Count > 1)
+		{
+			_rows[^1].MarginBottom = -list.ListPadding;
+		}
+
+		var topCover = new UIImage(TextureAssets.MagicPixel)
+		{
+			IgnoresMouseInteraction = true,
+			Color = BackgroundColor,
+			ScaleToFit = true,
+		};
+		topCover.Top.Set(-(TopCoverBar + Pad - 2f), 0f);
+		topCover.Left.Set(-69f, 1f);
+		topCover.Width.Set(63f, 0f);
+		topCover.Height.Set(TopCoverBar, 0f);
+		Append(topCover);
+
+		OnRowSelected(selectedIndex);
+	}
+
+	private void OnRowSelected(int index)
+	{
+		for (int i = 0; i < _rows.Count; i++)
+		{
+			_rows[i].SetSelected(i == index);
+		}
+
+		SelectedIndexChanged?.Invoke(this, index);
+	}
+
+	private sealed class ModFilterDropdownRow : UIPanel
+	{
+		private bool _selected;
+
+		private int Index { get; }
+
+		public ModFilterDropdownRow(int index, string displayText, bool selected, Action<int> onSelect)
+		{
+			Index = index;
+			_selected = selected;
+
+			Width.Set(0f, 1f);
+			Height.Set(30f, 0f);
+
+			var label = new UIText(displayText, 0.85f) { VAlign = 0.5f };
+			Append(label);
+
+			OnLeftClick += (_, _) => onSelect?.Invoke(Index);
+			OnMouseOver += (_, _) =>
+			{
+				if (!_selected)
+				{
+					BackgroundColor = Color.DarkRed * 0.3f;
+					BorderColor = Color.DarkRed * 0.3f;
+				}
+			};
+			OnMouseOut += (_, _) => Refresh();
+
+			Refresh();
+		}
+
+		public void SetSelected(bool selected)
+		{
+			_selected = selected;
+			Refresh();
+		}
+
+		private void Refresh()
+		{
+			BackgroundColor = _selected ? Color.DarkRed : Color.Transparent;
+			BorderColor = _selected ? Color.DarkRed : Color.Transparent;
+		}
+	}
+}

--- a/UIElements/ModFilterDropdown.cs
+++ b/UIElements/ModFilterDropdown.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Graphics;
 using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
+using Terraria.ModLoader.UI;
 using Terraria.UI;
 
 namespace RecipeBrowser.UIElements;
@@ -110,20 +113,28 @@ internal sealed class ModFilterDropdown : UIPanel
 
 	private sealed class ModFilterDropdownRow : UIPanel
 	{
+		private const float TextScale = 0.85f;
+
+		private readonly string _fullText;
+		private readonly UIText _label;
+		
 		private bool _selected;
+		private bool _hasComputedTruncation;
+		private bool _isTruncated;
 
 		private int Index { get; }
 
 		public ModFilterDropdownRow(int index, string displayText, bool selected, Action<int> onSelect)
 		{
-			Index = index;
+			_fullText = displayText;
 			_selected = selected;
+			Index = index;
 
 			Width.Set(0f, 1f);
 			Height.Set(30f, 0f);
 
-			var label = new UIText(displayText, 0.85f) { VAlign = 0.5f };
-			Append(label);
+			_label = new UIText(displayText, TextScale) { VAlign = 0.5f };
+			Append(_label);
 
 			OnLeftClick += (_, _) => onSelect?.Invoke(Index);
 			OnMouseOver += (_, _) =>
@@ -145,10 +156,75 @@ internal sealed class ModFilterDropdown : UIPanel
 			Refresh();
 		}
 
+		protected override void DrawSelf(SpriteBatch spriteBatch)
+		{
+			base.DrawSelf(spriteBatch);
+			
+			if (!_hasComputedTruncation)
+			{
+				ComputeTruncationOnce();
+				_hasComputedTruncation = true;
+			}
+			
+			if (_isTruncated && IsMouseHovering)
+			{
+				UICommon.TooltipMouseText(_fullText);
+			}
+		}
+		
 		private void Refresh()
 		{
 			BackgroundColor = _selected ? Color.DarkRed : Color.Transparent;
 			BorderColor = _selected ? Color.DarkRed : Color.Transparent;
+		}
+		
+		private void ComputeTruncationOnce()
+		{
+			float availablePx = GetInnerDimensions().Width;
+			if (availablePx <= 0f)
+			{
+				_label.SetText(string.Empty);
+				_isTruncated = true;
+				return;
+			}
+			
+			DynamicSpriteFont font = FontAssets.MouseText.Value;
+			float maxUnits = availablePx / TextScale;
+			
+			float fullUnits = font.MeasureString(_fullText).X;
+			if (fullUnits <= maxUnits)
+			{
+				_label.SetText(_fullText);
+				_isTruncated = false;
+				return;
+			}
+			
+			const string ellipsis = "...";
+			float ellipsisUnits = font.MeasureString(ellipsis).X;
+			if (ellipsisUnits > maxUnits)
+			{
+				_label.SetText(string.Empty);
+				_isTruncated = true;
+				return;
+			}
+			
+			int minLength = 0, maxLength = _fullText.Length;
+			while (minLength < maxLength)
+			{
+				int candidateLength = (minLength + maxLength + 1) >> 1;
+				float units = font.MeasureString(_fullText[..candidateLength]).X + ellipsisUnits;
+				if (units <= maxUnits)
+				{
+					minLength = candidateLength;
+				}
+				else
+				{
+					maxLength = candidateLength - 1;
+				}
+			}
+			
+			_label.SetText(_fullText[..minLength] + ellipsis);
+			_isTruncated = true;
 		}
 	}
 }

--- a/UIElements/UIHoverImageButtonMod.cs
+++ b/UIElements/UIHoverImageButtonMod.cs
@@ -32,11 +32,13 @@ namespace RecipeBrowser
 			else {
 				base.DrawSelf(spriteBatch);
 			}
-			if (IsMouseHovering && texture != null)
+			if ((IsMouseHovering || RecipeBrowserUI.modHoverIndex != -1) && texture != null)
 			{
 				Rectangle hitbox = GetInnerDimensions().ToRectangle();
 				spriteBatch.Draw(texture, new Vector2(hitbox.X + hitbox.Width / 2 - 40, hitbox.Y - 80), Color.White);
 			}
+
+			RecipeBrowserUI.modHoverIndex = -1;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Introduce a dropdown mod selector that is enabled only when `mods.Length >= 4` (Vanilla counts as one, i.e., Vanilla + 3 item-providing mods). It opens on left-click; middle and right clicks keep their existing behavior. For `mods.Length <= 3`, keep the previous selection mechanism.

## Changes
- Add `ModFilterDropdown` control.
- Update `ModFilterButton_OnClick` to create the dropdown once and toggle by attach/detach (no re-create).
- Re-append the dropdown on panel changes to preserve draw order.
- Add truncation of the mod name when it’s too long, and show the full name in a tooltip on hover.
- Minor refactor of `ModFilterButton` methods/logic for clarity.

## Points to consider
- Dropdown placement - maybe it should sit next to the main window.
- Close on row selection - can make that a config toggle.

### Closes #149